### PR TITLE
possible to skip the validation when the certificate is expired

### DIFF
--- a/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
+++ b/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
@@ -56,7 +56,7 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             return;
         }
 
-
+        $this->_input = $input;
 
         $modules = $this->getModules()
                 ->filterModules($input);

--- a/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
+++ b/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
@@ -84,7 +84,8 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             $curl->setHeader('Accept', 'application/json');
             $curl->setHeader('Content-Type', 'application/json');
             $curl->setHeader('Content-Length', strlen($listModulesJson));
-
+            $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+            
             $curl->post(self::TOOLS_HYPERNODE_MODULE_URL, $listModulesJson);
 
             $response = $curl->response;

--- a/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
+++ b/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
@@ -84,9 +84,18 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             $curl->setHeader('Accept', 'application/json');
             $curl->setHeader('Content-Type', 'application/json');
             $curl->setHeader('Content-Length', strlen($listModulesJson));
-            $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
             
             $curl->post(self::TOOLS_HYPERNODE_MODULE_URL, $listModulesJson);
+
+            if($curl->curl_error_code === 60){
+                $dialog = $this->getHelperSet()->get('dialog');
+                $verifySSL = $dialog->askConfirmation($output,
+                    '<question>The SSL certificate at tools.hypernode.com could not be verified and might be expired, continue without verifying?</question> <comment>[yes]</comment> ', true);
+                if($verifySSL){
+                    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+                    $curl->post(self::TOOLS_HYPERNODE_MODULE_URL, $listModulesJson);
+                }
+            }
 
             $response = $curl->response;
         } catch (Exception $e) {

--- a/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
+++ b/src/Hypernode/Magento/Command/System/Modules/ListUpdatesCommand.php
@@ -14,6 +14,8 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
 {
     const TOOLS_HYPERNODE_MODULE_URL = 'https://tools.hypernode.com/modules/magerun.json';
 
+    protected $_input;
+
     protected function configure()
     {
         $this
@@ -21,6 +23,7 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             ->addOption('codepool', null, InputOption::VALUE_OPTIONAL, 'Show modules in a specific codepool')
             ->addOption('status', null, InputOption::VALUE_OPTIONAL, 'Show modules with a specific status')
             ->addOption('vendor', null, InputOption::VALUE_OPTIONAL, 'Show modules of a specified vendor')
+            ->addOption('no-verify', null, InputOption::VALUE_NONE, 'Do not verify the SSL certificate')
             ->setDescription('Find available updates for installed modules [Hypernode]')
             ->addOption(
                 'format',
@@ -53,6 +56,8 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             return;
         }
 
+
+
         $modules = $this->getModules()
                 ->filterModules($input);
 
@@ -78,20 +83,23 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
         }
 
         try {
-
             $curl = $this->getCurl();
 
             $curl->setHeader('Accept', 'application/json');
             $curl->setHeader('Content-Type', 'application/json');
             $curl->setHeader('Content-Length', strlen($listModulesJson));
+
+            if($this->_input->getOption('no-verify')){
+                $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+            }
             
             $curl->post(self::TOOLS_HYPERNODE_MODULE_URL, $listModulesJson);
 
-            if($curl->curl_error_code === 60){
+            if($curl->curl_error_code === 60 && !$this->_input->getOption('no-verify')){
                 $dialog = $this->getHelperSet()->get('dialog');
                 $verifySSL = $dialog->askConfirmation($output,
                     '<question>The SSL certificate at tools.hypernode.com could not be verified and might be expired, continue without verifying?</question> <comment>[yes]</comment> ', true);
-                if($verifySSL){
+                if($verifySSL ){
                     $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
                     $curl->post(self::TOOLS_HYPERNODE_MODULE_URL, $listModulesJson);
                 }

--- a/src/Hypernode/Magento/Command/System/Patches/ListCommand.php
+++ b/src/Hypernode/Magento/Command/System/Patches/ListCommand.php
@@ -49,7 +49,15 @@ class ListCommand extends AbstractHypernodeCommand
 
         try {
             $curl = $this->getCurl();
-            $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+            if($curl->curl_error_code === 60){
+                $dialog = $this->getHelperSet()->get('dialog');
+                $verifySSL = $dialog->askConfirmation($output,
+                    '<question>The SSL certificate at tools.hypernode.com could not be verified and might be expired, continue without verifying?</question> <comment>[yes]</comment> ', true);
+                if($verifySSL){
+                    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+                    $curl->get($_patchUrl);
+                }
+            }
             $curl->get($_patchUrl);
             $patchesListJson = $curl->response;
         } catch (Exception $e) {

--- a/src/Hypernode/Magento/Command/System/Patches/ListCommand.php
+++ b/src/Hypernode/Magento/Command/System/Patches/ListCommand.php
@@ -49,6 +49,7 @@ class ListCommand extends AbstractHypernodeCommand
 
         try {
             $curl = $this->getCurl();
+            $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
             $curl->get($_patchUrl);
             $patchesListJson = $curl->response;
         } catch (Exception $e) {


### PR DESCRIPTION
The pull request contains commits with incremental functionality.
1. just skip the validation
2. ask the user to skip it
   3 / 4. also support a `--no-verify` parameter

It's better to renew the certificate but we might run into the same issue after 3 months.
