### PR TITLE
Buildscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ Flush all URL's that were cached by varnish.
 By default this command loads Magento's sitemap collection from which you can choose what sitemaps you want to crawl. If the store URL does not match the URL's in the sitemap you will be prompted several options (compare, replace, continue). For instance the old and new URL can be compared in a performance report. Additionally a sitemap can be loaded by specifying a path or URL. 
 
 
+Packaging
+--------
+
+For development/testing (build package of your feature branch):
+```
+gbp buildpackage --git-pbuilder --git-dist=precise --git-arch=amd64
+```
+
+Building a .deb for release:
+```
+./build.sh
+```
+
+Then if everything is alright, upload the new version to your repository with something like [dput](http://manpages.ubuntu.com/manpages/precise/man1/dput.1.html)
+
+
 Credits due where credits due
 --------
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e 
+
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then
+	echo "You are not on the master branch, aborting"
+	/bin/false
+fi;
+
+export VERSION=$(date "+%Y%m%d.%H%M%S")
+echo "Generating changelog changelog"
+gbp dch --debian-tag="%(version)s" --new-version=$VERSION --debian-branch master --release --commit
+echo "Building package"
+gbp buildpackage --git-pbuilder --git-dist=precise --git-arch=amd64 --git-debian-branch=master
+echo "Creating tag $VERSION"
+git tag $VERSION
+echo "Pushing tags"
+git push
+git push --tags
+echo "Great! Now run: dput -uf precise ../*$VERSION*.changes"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+magerun-hypernode (20161020.103357) xenial; urgency=medium
+
+  * Autodetect sitemap in ttfb script if no specified in silent mode
+
+ -- Rick van de Loo <vdloo@workstation4>  Thu, 20 Oct 2016 10:33:58 +0200
+
 magerun-hypernode (20160920.1231) precise; urgency=medium
 
   * Upstream release


### PR DESCRIPTION
## add build script for packaging

For consistent changelog formatting in the debian packaging. I'll
fabricate, tag and push previous releases `1.0-1` and `20160920.1231`
because they are missing from the repository.
