### PR TITLE
fix broken silent sitemap

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -80,7 +80,7 @@ class PerformanceCommand extends AbstractHypernodeCommand
         if (!$this->_options['sitemap'] && !$this->_options['silent']) {
             $this->_sitemaps = $this->askSitemapsToProcess($input, $output);
         } else {
-	    if ($this->_options['silent']) {
+	    if (!$this->_options['sitemap'] && $this->_options['silent']) {
 	        $this->_sitemaps = $this->retrieveSitemaps();
             } else {
                 $sitemapFromInput = $this->getSitemapFromInput($this->_options);


### PR DESCRIPTION
```
$ magerun hypernode:performance --silent --limit 100 --compare-url='vdloo.hypernode.io' --current-url='1.2.3.4' --sitemap=/tmp/sitemap.txt
```

would default to the Magento sitemaps instead of the specified sitemap, and if there is none fail silently
