### PR TITLE
add runtests.sh to run tests without setup

### DIFF
--- a/build/travis/before_script.sh
+++ b/build/travis/before_script.sh
@@ -4,28 +4,32 @@ grep -v 'remove uninstall test' phpunit.xml.dist > phpunit.xml
 
 if [ ! -z ${MAGENTO_VERSION+x} ]; then
 
-    echo "installing magento ${MAGENTO_VERSION}"
+    echo "ensuring magento ${MAGENTO_VERSION} is installed"
 
+    db_user="${SETUP_DB_USER:-root}"
     db_pass="${SETUP_DB_PASS:-}"
 
     if [ "" == "${db_pass}" ]; then
-        mysql -uroot -e 'CREATE DATABASE IF NOT EXISTS `magento_travis`;'
+        mysql -u"${db_user}" -e 'CREATE DATABASE IF NOT EXISTS `magento_travis`;'
     else
-        mysql -uroot -p"${db_pass}" -e 'CREATE DATABASE IF NOT EXISTS `magento_travis`;'
+        mysql -u"${db_user}" -p"${db_pass}" -e 'CREATE DATABASE IF NOT EXISTS `magento_travis`;'
     fi;
 
     target_directory="${SETUP_DIR:-./}${MAGENTO_VERSION}"
 
     export N98_MAGERUN_TEST_MAGENTO_ROOT="${target_directory}"
 
-    php -dmemory_limit=1g -f bin/n98-magerun -- install \
-                --magentoVersionByName="${MAGENTO_VERSION}" --installationFolder="${target_directory}" \
-                --dbHost=127.0.0.1 --dbUser=root --dbPass="${db_pass}" --dbName="magento_travis" \
-                --installSampleData=${INSTALL_SAMPLE_DATA} --useDefaultConfigParams=yes \
-                --baseUrl="http://travis.magento.local/"
+    if [ ! -f "${target_directory}/app/etc/config.xml" ]; then
+        php -dmemory_limit=1g -f bin/n98-magerun -- install \
+                    --magentoVersionByName="${MAGENTO_VERSION}" --installationFolder="${target_directory}" \
+                    --dbHost=127.0.0.1 --dbUser="${db_user}" --dbPass="${db_pass}" --dbName="magento_travis" \
+                    --installSampleData=${INSTALL_SAMPLE_DATA} --useDefaultConfigParams=yes \
+                    --baseUrl="${base_url:-http://travis.magento.local/}"
+    fi;
 
 else
 
     echo "no magento version to install"
 
 fi
+

--- a/build/vagrant/setup_and_run_tests.sh
+++ b/build/vagrant/setup_and_run_tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+export DB=mysql
+export MAGENTO_VERSION="magento-mirror-1.9.2.4"
+export INSTALL_SAMPLE_DATA=no
+export LINTSH=1
+export SETUP_DB_USER='app'
+export SETUP_DB_PASS=$(grep password ~/.my.cnf | cut -d'=' -f2 | xargs)
+export SETUP_DIR='/data/web/'
+
+# correct the magento-root-dir in the composer.json to match Hypernode's docroot
+sed -i 's/"magento-root-dir": "htdocs"/"magento-root-dir": "\/data\/web\/public\/'"$MAGENTO_VERSION"'"/g' composer.json
+
+composer config -g repositories.firegento composer https://packages.firegento.com
+composer install --prefer-source --no-interaction --ignore-platform-reqs
+bash /data/web/public/build/travis/before_script.sh
+
+# Lint PHP code
+set +e
+find {src,tests} -name "*.php" ! -path '*/String.php' -print0 | xargs -0 -n1 -P8 php -l | grep -v '^No syntax errors detected' 
+if [ $? -ne 1 ]; then
+    echo "Syntax errors detected"
+    exit 1
+fi;
+set -e
+
+# Run the unit tests
+echo "Note: hypernode-vagrant does not support Xdebug at this moment."
+echo -e "Tests that require Xdebug will be skipped\n"
+vendor/bin/phpunit --debug --stop-on-error --stop-on-failure
+
+# If something is not OK we would have errored out before here
+echo "Looks like everything is OK"
+

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+TEST_COMMAND="bash build/vagrant/setup_and_run_tests.sh"
+TEST_USER='app'  # Other options: root, vagrant (can sudo while app can not)
+
+HYPERNODE_VAGRANT_RUNNER_REPO="https://github.com/ByteInternet/hypernode-vagrant"
+HYPERNODE_VAGRANT_RUNNER_DIR='/tmp/hypernode-vagrant-runner'
+PROJECT_DIRECTORY="$(dirname "$(readlink -f "$0")")"
+
+
+if [ -d "$HYPERNODE_VAGRANT_RUNNER_DIR" ]; then
+    echo "Ensuring the hypernode-vagrant-runner is the latest version in $HYPERNODE_VAGRANT_RUNNER_DIR"
+    cd "$HYPERNODE_VAGRANT_RUNNER_DIR"
+    git clean -xfd
+    git pull origin master || /bin/true
+    git reset --hard origin/master
+    cd -
+else
+    echo "Creating a new checkout of hypernode-vagrant-runner in $HYPERNODE_VAGRANT_RUNNER_DIR"
+    git clone $HYPERNODE_VAGRANT_RUNNER_REPO $HYPERNODE_VAGRANT_RUNNER_DIR
+fi;
+
+chmod +x ${HYPERNODE_VAGRANT_RUNNER_DIR}/tools/hypernode-vagrant-runner/bin/start_runner.py
+PYTHONPATH=${HYPERNODE_VAGRANT_RUNNER_DIR}/tools/hypernode-vagrant-runner \
+    ${HYPERNODE_VAGRANT_RUNNER_DIR}/tools/hypernode-vagrant-runner/bin/start_runner.py \
+    --project-path="$PROJECT_DIRECTORY" \
+    --command-to-run="$TEST_COMMAND" \
+    --user="$TEST_USER" \
+    "$@"  # All other arguments. So you can run ./runtests.sh -1 or --help for example
+


### PR DESCRIPTION
In a hypernode-vagrant https://github.com/ByteInternet/hypernode-vagrant/pull/112

Right now you can already run ./build/local/test_setup.sh but I do not want to make changes to my host system in order to run the tests for this repo. This PR adds a `./runtests.sh` that will take care of setting up the test environment and running the tests in a repl (got to have Vagrant/Virtualbox/git/rsync/python installed though).

```
$ ./runtests.sh
Creating a new checkout of hypernode-vagrant-runner in /tmp/hypernode-vagrant-runner
Cloning into '/tmp/hypernode-vagrant-runner'...
remote: Counting objects: 830, done.
remote: Compressing objects: 100% (74/74), done.
remote: Total 830 (delta 9), reused 0 (delta 0), pack-reused 753
Receiving objects: 100% (830/830), 746.63 KiB | 235.00 KiB/s, done.
Resolving deltas: 100% (369/369), done.
Checking connectivity... done.
Testing we can sudo
yes we can sudo
Ensuring directory for checkout
Creating temporary directory
Cloning hypernode-vagrant
Cloning into '/tmp/tmpDJPdvi'...
remote: Counting objects: 830, done.
remote: Compressing objects: 100% (74/74), done.
remote: Total 830 (delta 9), reused 0 (delta 0), pack-reused 753
Receiving objects: 100% (830/830), 746.63 KiB | 185.00 KiB/s, done.
Resolving deltas: 100% (369/369), done.
Checking connectivity... done.
Ensuring Vagrant plugin vagrant-vbguest is installed
vagrant-vbguest (0.13.0)
Ensuring Vagrant plugin vagrant-hypconfigmgmt is installed
vagrant-hypconfigmgmt (0.0.4)
Writing configuration file to the hypernode-vagrant directory
Running 'vagrant up' in the hypernode-vagrant checkout directory. This can take a while.
Bringing machine 'hypernode' up with 'virtualbox' provider...
...
Uploading project /home/vdloo/code/projects/hypernode-magerun to /data/web/public on the vagrant..
...
Updating dependencies (including require-dev)
Package operations: 53 installs, 0 updates, 0 removals
  - Installing twig/twig (1.x-dev 08bd6f1)
    Cloning 08bd6f15a5b411988d4146ab6e3b109fd632f63e
...
```