### PR TITLE
test 1.9.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - MAGENTO_VERSION="magento-mirror-1.8.1.0" INSTALL_SAMPLE_DATA=yes
     - MAGENTO_VERSION="magento-mirror-1.9.2.1" INSTALL_SAMPLE_DATA=no
     - MAGENTO_VERSION="magento-mirror-1.9.2.4" INSTALL_SAMPLE_DATA=no
+    - MAGENTO_VERSION="magento-mirror-1.9.3.0" INSTALL_SAMPLE_DATA=no
 
 matrix:
   fast_finish: true
@@ -44,7 +45,7 @@ matrix:
     - php: 7.0
       env: MAGENTO_VERSION="magento-mirror-1.9.2.1" DB=mysql INSTALL_SAMPLE_DATA=no
     - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.9.2.4" DB=mysql INSTALL_SAMPLE_DATA=no
+      env: MAGENTO_VERSION="magento-mirror-1.9.3.0" DB=mysql INSTALL_SAMPLE_DATA=no
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/build/vagrant/setup_and_run_tests.sh
+++ b/build/vagrant/setup_and_run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 export DB=mysql
-export MAGENTO_VERSION="magento-mirror-1.9.2.4"
+export MAGENTO_VERSION="magento-mirror-1.9.3.0"
 export INSTALL_SAMPLE_DATA=no
 export LINTSH=1
 export SETUP_DB_USER='app'


### PR DESCRIPTION
1.9.3.1 doesn't seem available through this mirror yet
```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.
Nothing to install or update
Generating autoload files
Warning: Using a password on the command line interface can be insecure.

  [InvalidArgumentException]
  Unable to locate Magento version

install [--magentoVersion [MAGENTOVERSION]] [--magentoVersionByName [MAGENTOVERSIONBYNAME]] [--installationFolder [INSTALLATIONFOLDER]] [--dbHost [DBHOST]] [--dbUser [DBUSER]] [--dbPass [DBPASS]] [--dbName [DBNAME]] [--dbPort [DBPORT]] [--dbPrefix [DBPREFIX]] [--installSampleData [INSTALLSAMPLEDATA]] [--useDefaultConfigParams [USEDEFAULTCONFIGPARAMS]] [--baseUrl [BASEURL]] [--replaceHtaccessFile [REPLACEHTACCESSFILE]] [--noDownload] [--only-download] [--forceUseDb] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [--root-dir [ROOT-DIR]] [--skip-config] [--skip-root-check] [--] <command>

Running command in Vagrant exited nonzero
/data/web/public/magento-mirror-1.9.3.1/app/Mage.php is not a file.
ensuring magento magento-mirror-1.9.3.1 is installed

  Magento Installation
```