### PR TITLE
Fix www. issue in Nginx maps generate command

### DIFF
--- a/tests/Hypernode/Magento/Command/Hypernode/Config/GenerateMapsCommandTest.php
+++ b/tests/Hypernode/Magento/Command/Hypernode/Config/GenerateMapsCommandTest.php
@@ -54,7 +54,6 @@ class GenerateMapsCommandTest extends TestCase
                 ->getOption('save')->getName());
     }
 
-
     public function testExecute()
     {
         $command = $this->getCommand();
@@ -65,6 +64,7 @@ class GenerateMapsCommandTest extends TestCase
         $result = $commandTester->getDisplay();
 
         $this->assertRegExp('/^(.*?(Mage run maps for Nginx. \[Byte Hypernode\] )[^$]*)$/m',$result);
+        $this->assertNotContains('www.',$result);
     }
 
 }


### PR DESCRIPTION
Domains defined with a www. prefix we're outputted in the following way:

```
map $host $storecode {
 hostnames; 
default default;
.hypermage.dev default; 
.hypermage-french.dev french; 
.hypermage-german.dev german; 
.nl.hypermage.dev nl; 
.www.supermage.dev wwwstv; <!-- fix -->
}
```

As stated [here](https://support.hypernode.com/knowledgebase/configure-run-codes-and-run-types-in-nginx/) the following change matches both www and non-www. Result:

```
map $host $storecode {
 hostnames; 
default default;
.hypermage.dev default; 
.hypermage-french.dev french; 
.hypermage-german.dev german; 
.nl.hypermage.dev nl; 
.supermage.dev wwwstv; 
}
```

additionally some refactoring has been done.