### PR TITLE
Modules updates

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommand.php
@@ -33,24 +33,27 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             ->addOption('codepool', null, InputOption::VALUE_OPTIONAL, 'Show modules in a specific codepool')
             ->addOption('status', null, InputOption::VALUE_OPTIONAL, 'Show modules with a specific status')
             ->addOption('vendor', null, InputOption::VALUE_OPTIONAL, 'Show modules of a specified vendor')
+            ->addOption('only-active', null, InputOption::VALUE_NONE, 'Ignore inactive modules')
             ->setDescription('Find available updates for installed modules.')
             ->addOption(
                 'format',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+                'Output Format. One of ['.implode(',', RendererFactory::getFormats()).']'
             );
     }
 
     /**
-     * Get modules
-     *
+     * Returns an Object with Magento modules
+     * @param $input InputInterface
      * @return Modules
      */
-    public function getModules()
+    public function getModules($input)
     {
         $modules = new Modules();
-        return $modules->findInstalledModules();
+        $modules = $modules->findInstalledModules()->filterModules($input);
+
+        return $modules;
     }
 
     /**
@@ -65,8 +68,8 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             return;
         }
 
-        $modules = $this->getModules()
-                ->filterModules($input);
+        $onlyActive = $input->getOption('only-active') ? true : false;
+        $modules = $this->getModules($input);
 
         if (!count($modules)) {
             $output->writeln('<error>Could not parse sys:modules:list</error>');
@@ -74,20 +77,28 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
         }
 
         // Compatibility fix
-        $listModules = array_map(function($item){
-            return array_combine(array('codePool', 'Name', 'Version', 'Status'), $item);
-        }, iterator_to_array($modules));
+        $listModules = array_map(
+            function ($item) {
+                return array_combine(array('codePool', 'Name', 'Version', 'Status'), $item);
+            },
+            iterator_to_array($modules)
+        );
 
         $options = JSON_FORCE_OBJECT;
         if (version_compare(PHP_VERSION, '5.4', '>=')) {
             $options |= JSON_PRETTY_PRINT;
         }
-        $listModulesJson = json_encode($listModules, $options);
 
         $modulesInfo = array();
         foreach ($listModules as $moduleInfo) {
+
+            if (!$moduleInfo['Version']) {
+                $moduleInfo['Version'] = $this->getExtensionVersion($moduleInfo['Name']);
+            }
             $modulesInfo[$moduleInfo['Name']] = $moduleInfo;
         }
+
+        $modulesInfoJson = json_encode($modulesInfo, $options);
 
         try {
 
@@ -95,13 +106,15 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
 
             $curl->setHeader('Accept', 'application/json');
             $curl->setHeader('Content-Type', 'application/json');
-            $curl->setHeader('Content-Length', strlen($listModulesJson));
+            $curl->setHeader('Content-Length', strlen($modulesInfoJson));
 
-            $curl->post(self::TOOLS_HYPERNODE_MODULE_URL, $listModulesJson);
+            $curl->post(self::TOOLS_HYPERNODE_MODULE_URL, $modulesInfoJson);
 
             $response = $curl->response;
-        } catch (Exception $e) {
-            $output->writeln('<error>Could not fetch data from Hypernode platform; ' . $e->getMessage() . '</error>');
+
+
+        } catch (\Exception $e) {
+            $output->writeln('<error>Could not fetch data from Hypernode platform; '.$e->getMessage().'</error>');
             exit(1);
         }
 
@@ -115,24 +128,32 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
 
         $rowsUpdates = $rowsLatest = array();
         foreach (array_pop($responseData) as $module) {
+
             $tableInfo = array_merge($module, $modulesInfo[$module['name']]);
 
-            $update = array($tableInfo['Name'], $tableInfo['codePool'], $tableInfo['current'], $tableInfo['latest']);
+            // inactive / active filtering
+            if ($tableInfo['Status'] === 'inactive' && $doFormat && !$onlyActive) {
+                $tableInfo['Name'] = '<error>'.$tableInfo['Name'].' (inactive)</error>';
+            } elseif ($onlyActive && $tableInfo['Status'] === 'inactive') {
+                continue;
+            }
 
-            $hasUpdate = $tableInfo['current'] != $tableInfo['latest'];
+            $update = array(
+                $tableInfo['Name'],
+                $tableInfo['codePool'],
+                $tableInfo['current'],
+                $tableInfo['latest'],
+                $tableInfo['Status'],
+            );
+
+            $hasUpdate = $tableInfo['current'] !== $tableInfo['latest'];
 
             if ($doFormat) {
-                $update[] = ($hasUpdate ? '<comment>Yes</comment>' : '<info>No</info>') . '';
+                $update[] = ($hasUpdate ? '<comment>Yes</comment>' : '<info>No</info>').'';
             } else {
                 $update[] = ($hasUpdate ? 'Yes' : 'No');
             }
 
-            /**
-             * No inactive modules are sent back from the Hypernode platform; maybe later?
-             */
-            /*if($tableInfo['Status'] == 'inactive') {
-                $tableInfo['Name'] .= ' <error>(inactive)</error>';
-            }*/
             if ($hasUpdate) {
                 $rowsUpdates[] = $update;
             } else {
@@ -143,8 +164,48 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
         $rows = array_merge($rowsLatest, array(new TableSeparator()), $rowsUpdates);
 
         $this->getHelper('table')
-                ->setHeaders(array('Name', 'Code pool', 'Current version', 'Latest version', 'Newer version available?'))
-                ->renderByFormat($output, $rows, $input->getOption('format'));
+            ->setHeaders(
+                array('Name', 'Code pool', 'Current version', 'Latest version', 'Status', 'Newer version available?')
+            )
+            ->renderByFormat($output, $rows, $input->getOption('format'));
+    }
+
+    /**
+     * Finds out the version of a disabled / inactive module
+     *
+     * 1. Checks if the module version can be found in config (cache)
+     * 2. Else checks the modules' config.xml for the version
+     *
+     * @param $namespace
+     * @return bool|string|null
+     */
+    protected function getExtensionVersion($namespace)
+    {
+        /**
+         * Is it in config cache?
+         */
+        if ($versionFromCache = (string)\Mage::getConfig()->getNode()->modules->{$namespace}->version) {
+            return $versionFromCache;
+        }
+
+        $moduleDir = \Mage::getConfig()->getModuleDir('etc', $namespace);
+
+        if (file_exists($moduleDir)) {
+
+            $configFile = $moduleDir.DIRECTORY_SEPARATOR.'config.xml';
+
+            if ($xml = file_get_contents($configFile)) {
+
+                $config = new \Varien_Simplexml_Config($xml);
+
+                if ($version = $config->getNode('modules')->descend($namespace)->asArray()) {
+                    return $version['version'];
+                }
+            }
+        }
+
+        // returning null for version will exclude the module from getting version info
+        return null;
     }
 
 }

--- a/src/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommand.php
@@ -39,7 +39,7 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
                 'format',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Output Format. One of ['.implode(',', RendererFactory::getFormats()).']'
+                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
             );
     }
 
@@ -114,7 +114,7 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
 
 
         } catch (\Exception $e) {
-            $output->writeln('<error>Could not fetch data from Hypernode platform; '.$e->getMessage().'</error>');
+            $output->writeln('<error>Could not fetch data from Hypernode platform; ' . $e->getMessage() . '</error>');
             exit(1);
         }
 
@@ -133,7 +133,7 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
 
             // inactive / active filtering
             if ($tableInfo['Status'] === 'inactive' && $doFormat && !$onlyActive) {
-                $tableInfo['Name'] = '<error>'.$tableInfo['Name'].' (inactive)</error>';
+                $tableInfo['Name'] = '<error>' . $tableInfo['Name'] . ' (inactive)</error>';
             } elseif ($onlyActive && $tableInfo['Status'] === 'inactive') {
                 continue;
             }
@@ -149,7 +149,7 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             $hasUpdate = $tableInfo['current'] !== $tableInfo['latest'];
 
             if ($doFormat) {
-                $update[] = ($hasUpdate ? '<comment>Yes</comment>' : '<info>No</info>').'';
+                $update[] = ($hasUpdate ? '<comment>Yes</comment>' : '<info>No</info>') . '';
             } else {
                 $update[] = ($hasUpdate ? 'Yes' : 'No');
             }
@@ -161,7 +161,12 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             }
         }
 
-        $rows = array_merge($rowsLatest, array(new TableSeparator()), $rowsUpdates);
+        // do not show empty row if there are no updates
+        if (count($rowsUpdates) < 1) {
+            $rows = $rowsLatest;
+        } else {
+            $rows = array_merge($rowsLatest, array(new TableSeparator()), $rowsUpdates);
+        }
 
         $this->getHelper('table')
             ->setHeaders(
@@ -192,7 +197,7 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
 
         if (file_exists($moduleDir)) {
 
-            $configFile = $moduleDir.DIRECTORY_SEPARATOR.'config.xml';
+            $configFile = $moduleDir . DIRECTORY_SEPARATOR . 'config.xml';
 
             if ($xml = file_get_contents($configFile)) {
 

--- a/src/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommand.php
@@ -68,7 +68,6 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             return;
         }
 
-        $onlyActive = $input->getOption('only-active') ? true : false;
         $modules = $this->getModules($input);
 
         if (!count($modules)) {
@@ -132,9 +131,9 @@ class ListUpdatesCommand extends AbstractHypernodeCommand
             $tableInfo = array_merge($module, $modulesInfo[$module['name']]);
 
             // inactive / active filtering
-            if ($tableInfo['Status'] === 'inactive' && $doFormat && !$onlyActive) {
+            if ($tableInfo['Status'] === 'inactive' && $doFormat && ! $input->getOption('only-active')) {
                 $tableInfo['Name'] = '<error>' . $tableInfo['Name'] . ' (inactive)</error>';
-            } elseif ($onlyActive && $tableInfo['Status'] === 'inactive') {
+            } elseif ($input->getOption('only-active') && $tableInfo['Status'] === 'inactive') {
                 continue;
             }
 

--- a/tests/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommandTest.php
+++ b/tests/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommandTest.php
@@ -132,12 +132,23 @@ class ListUpdatesCommandTest extends TestCase
                     'name' => 'Mage_Catalog',
                 ],
                 [
-                    'latest' => '0.2',
-                    'current' => '0.2',
-                    'name' => 'Cm_RedisSession',
+                    'latest' => '1.6.0.0',
+                    'current' => '1.6.0.0',
+                    'name' => 'Phoenix_Moneybookers',
                 ]
             ]
         ]);
+
+        // disable module
+        $disableCommand = $this->getApplication()->find('dev:module:disable');
+
+        $disableExecute = new CommandTester($disableCommand);
+
+        $disableExecute->execute(array(
+            'command' => $disableCommand->getName(),
+            '--codepool' => 'community',
+            'moduleName' => 'Phoenix_Moneybookers'
+        ));
 
         // Set mock
         $command->setCurl($curl);

--- a/tests/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommandTest.php
+++ b/tests/Hypernode/Magento/Command/Hypernode/Modules/ListUpdatesCommandTest.php
@@ -12,6 +12,7 @@ namespace Hypernode\Magento\Command\Hypernode\Modules;
 
 use Hypernode\Curl;
 use N98\Magento\Command\PHPUnit\TestCase;
+use N98\Magento\Modules;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -21,9 +22,16 @@ use Symfony\Component\Console\Tester\CommandTester;
 class ListUpdatesCommandTest extends TestCase
 {
 
+    /**
+     * @var Modules $modules
+     */
+    public $modules;
+
     public function setUp()
     {
+        $this->modules = new Modules();
         $application = $this->getApplication();
+        /** @var ListUpdatesCommand $command */
         $command = new ListUpdatesCommand();
 
         $application->add($command);
@@ -32,7 +40,13 @@ class ListUpdatesCommandTest extends TestCase
     public function getCommand()
     {
         return $this->getApplication()
-                ->find('hypernode:modules:list-updates');
+            ->find('hypernode:modules:list-updates');
+    }
+
+    public function testModules()
+    {
+        $modules = $this->modules;
+        $this->assertInstanceOf(Modules::class, $modules);
     }
 
     public function testName()
@@ -45,13 +59,15 @@ class ListUpdatesCommandTest extends TestCase
     {
         $command = $this->getCommand();
         $this->assertEquals('codepool', $command->getDefinition()
-                ->getOption('codepool')->getName());
+            ->getOption('codepool')->getName());
         $this->assertEquals('status', $command->getDefinition()
-                ->getOption('status')->getName());
+            ->getOption('status')->getName());
         $this->assertEquals('vendor', $command->getDefinition()
-                ->getOption('vendor')->getName());
+            ->getOption('vendor')->getName());
+        $this->assertEquals('only-active', $command->getDefinition()
+            ->getOption('only-active')->getName());
         $this->assertEquals('format', $command->getDefinition()
-                ->getOption('format')->getName());
+            ->getOption('format')->getName());
     }
 
 
@@ -62,22 +78,22 @@ class ListUpdatesCommandTest extends TestCase
         $curl = $this->getMock(Curl::class, ['post']);
 
         $curl->expects($this->once())
-                ->method('post')
-                ->with($this->equalTo($command::TOOLS_HYPERNODE_MODULE_URL));
+            ->method('post')
+            ->with($this->equalTo($command::TOOLS_HYPERNODE_MODULE_URL));
 
         $curl->response = json_encode([
-                'versions' => [
-                        [
-                            'latest' => '1.2.3',
-                            'current' => '0.0.0',
-                            'name' => 'Mage_Core',
-                        ],
-                        [
-                            'latest' => '1.2.3',
-                            'current' => '1.2.3',
-                            'name' => 'Mage_Catalog',
-                        ]
+            'versions' => [
+                [
+                    'latest' => '1.2.3',
+                    'current' => '0.0.0',
+                    'name' => 'Mage_Core',
+                ],
+                [
+                    'latest' => '1.2.3',
+                    'current' => '1.2.3',
+                    'name' => 'Mage_Catalog',
                 ]
+            ]
         ]);
 
         // Set mock
@@ -90,6 +106,53 @@ class ListUpdatesCommandTest extends TestCase
 
         $this->assertRegExp('/Mage_Core.*Yes/', $result);
         $this->assertRegExp('/Mage_Catalog.*No/', $result);
+    }
+
+    public function testOnlyActive()
+    {
+
+        $command = $this->getCommand();
+
+        $curl = $this->getMock(Curl::class, ['post']);
+
+        $curl->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo($command::TOOLS_HYPERNODE_MODULE_URL));
+
+        $curl->response = json_encode([
+            'versions' => [
+                [
+                    'latest' => '1.2.3',
+                    'current' => '0.0.0',
+                    'name' => 'Mage_Core',
+                ],
+                [
+                    'latest' => '1.2.3',
+                    'current' => '1.2.3',
+                    'name' => 'Mage_Catalog',
+                ],
+                [
+                    'latest' => '0.2',
+                    'current' => '0.2',
+                    'name' => 'Cm_RedisSession',
+                ]
+            ]
+        ]);
+
+        // Set mock
+        $command->setCurl($curl);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute(
+            array(
+                'command' => $command->getName(),
+                '--only-active' => true,
+            )
+        );
+
+        $result = $commandTester->getDisplay();
+
+        $this->assertNotContains('(inactive)', $result);
     }
 
 }


### PR DESCRIPTION
For maintenance / store cleaning purposes, these changes also add information about disabled  / inactive modules. This provides the developer with information, whether modules can be updated and re-enabled or removed. This basically implements the following code comment:

```
            /**		
             * No inactive modules are sent back from the Hypernode platform; maybe later?		
             */		
            /*if($tableInfo['Status'] == 'inactive') {		
                $tableInfo['Name'] .= ' <error>(inactive)</error>';		
            }*/
```

disabled / inactive modules's configuration isn't loaded by Magento, an additional function tries to find it's version number from the config file. This enables the hypernode platform to deliver information about it.

The column **status** is added and disabled modules are marked red. The parameter --only-active makes the command skip these. If a version cannot be detected, no information about it will be returned. 