### PR TITLE
fix missing buildecho in vagrant test setup

### DIFF
--- a/build/vagrant/setup_and_run_tests.sh
+++ b/build/vagrant/setup_and_run_tests.sh
@@ -8,6 +8,12 @@ export SETUP_DB_USER='app'
 export SETUP_DB_PASS=$(grep password ~/.my.cnf | cut -d'=' -f2 | xargs)
 export SETUP_DIR='/data/web/'
 
+buildecho()
+{
+    echo -en "\e[1;44;97m[TEST-SETUP]\e[0m "
+    echo "${1}"
+}
+
 composer config -g repositories.firegento composer https://packages.firegento.com
 composer install --prefer-source --no-interaction --ignore-platform-reqs
 bash /data/web/public/build/travis/before_script.sh


### PR DESCRIPTION
from https://github.com/Hypernode/hypernode-magerun/pull/37


> There is a small issue with running the tests in the Vagrant:

```
build/vagrant/setup_and_run_tests.sh: line 31: buildecho: command not found
```

> we need to add the buildecho bash function from `build/local/test_setup.sh` to `build/vagrant/setup_and_run_tests.sh` or just use echo instead.
```
buildecho()
{
    echo -en "\e[1;44;97m[TEST-SETUP]\e[0m "
    echo "${1}"
}
```

```
[TEST-SETUP] stopfile .n98-magerun exists: /data/web/magento-mirror-1.9.2.4
PHPUnit 4.8.31 by Sebastian Bergmann and contributors.


Starting test 'Hypernode\Magento\Command\AbstractHypernodeCommandTest::testSetter'.
...

Time: 24.33 seconds, Memory: 28.00MB

OK (21 tests, 36 assertions)
Looks like everything is OK
```
