### PR TITLE
Fix notice level error for output of bounds.

### DIFF
--- a/src/Hypernode/PasswordCracker/Mutator/ToggleAt.php
+++ b/src/Hypernode/PasswordCracker/Mutator/ToggleAt.php
@@ -29,7 +29,10 @@ class ToggleAt extends AbstractMutator
 
     public function mutate($input)
     {
-        $i = $this->getArg(1);
+        $i = $this->getPositionArg(1);
+        if (! $this->validatePosition($i, $input)) {
+            return $input;
+        }
         $l = $input[$i];
         $r = ($l === strtoupper($l) ? strtolower($l) : strtoupper($l));
 


### PR DESCRIPTION
The mutator attempted to access an index of the string without checking
if it's out of bounds. Add check to insure index is less that string
length.