### PR TITLE
Do not list reverted patches as applied

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Patches/ListCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Patches/ListCommand.php
@@ -134,12 +134,21 @@ class ListCommand extends AbstractHypernodeCommand
         }
         $ioAdapter->open(array('path' => $ioAdapter->dirname($this->patchFile)));
         $ioAdapter->streamOpen($this->patchFile, 'r');
+
         while ($buffer = $ioAdapter->streamRead()) {
-            if (stristr($buffer, '|')) {
-                $patchInfo = array_map('trim', explode('|', $buffer));
-                $this->appliedPatches[$this->_formatPatchName($patchInfo[1], $patchInfo[3])] = true;
+            if (false === strpos($buffer, '|')) {
+                continue;
+            }
+
+            $patchInfo = array_map('trim', explode('|', $buffer));
+            $patchName = $this->_formatPatchName($patchInfo[1], $patchInfo[3]);
+            if (in_array('REVERTED', $patchInfo)) {
+                unset($this->appliedPatches[$patchName]);
+            } else {
+                $this->appliedPatches[$patchName] = true;
             }
         }
+
         $ioAdapter->streamClose();
     }
 


### PR DESCRIPTION
The `hypernode:patches:list` command also lists patches that were reverted (and thus not applied anymore!). This PR removes a patch that is listed as `REVERTED` in the applied patches list.

As the applied patches list is read from top to bottom, a patch that was applied (will be added to applied array), then reverted (will be removed from applied array) and then applied again (will be added to applied array) will still give the correct output.

I tested it on a project where I reverted the SUPEE-9767 v2 patch (no worries, just for testing this):

![before and after](https://user-images.githubusercontent.com/2794908/28163556-f68df91a-67cb-11e7-95bb-798cb3480860.png)

(and indeed, I see now that SUPEE-1533 was reverted in this project in order to apply SUPEE-8788, http://devdocs.magento.com/guides/m1x/other/ht_install-patches.html#apply-8788)
