### PR TITLE
Make command hypernode:performance compatibly with n98-magerun2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,17 @@ Here's the easiest:
 1. Create ~/.n98-magerun/modules/ if it doesn't already exist.
 
         mkdir -p ~/.n98-magerun/modules/
+        mkdir -p ~/.n98-magerun2/modules/
 
 2. Clone the hypernode-magerun repository in there
 
         git clone https://github.com/Hypernode/hypernode-magerun.git ~/.n98-magerun/modules/hypernode-magerun
 
-3. It should be installed. To see that it was installed, run magerun without any arguments to see if one of the new commands is in there.
+3. Link the repository for n98-magerun2
+
+        ln -s ~/.n98-magerun/modules/hypernode-magerun ~/.n98-magerun2/modules/hypernode-magerun
+
+4. It should be installed. To see that it was installed, run magerun without any arguments to see if one of the new commands is in there.
 
         n98-magerun.phar
 
@@ -112,6 +117,12 @@ Building a .deb for release:
 
 Then if everything is alright, upload the new version to your repository with something like [dput](http://manpages.ubuntu.com/manpages/precise/man1/dput.1.html)
 
+n98-magerun2 compatibility
+-----------------------
+
+Currently, only the command `hypernode:perfomance` is partially compatible with n98-magerun2. 
+
+Please contribute to make more commands available for n98-magerun2!
 
 Credits due where credits due
 --------

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
   "require-dev": {
     "phpunit/phpunit": "~4.8",
     "mikey179/vfsStream": "1.6.4",
-    "n98/magerun": "dev-master"
+    "n98/magerun": "dev-master",
+    "firegento/magento": "~1.9.3",
+    "doctrine/instantiator": "~1.0.5"
   },
   "autoload": {
     "psr-0": {

--- a/n98-magerun2.yaml
+++ b/n98-magerun2.yaml
@@ -1,0 +1,12 @@
+autoloaders:
+  Hypernode: %module%/src
+
+commands:
+  customCommands:
+    - Hypernode\Magento\Command\Hypernode\Performance\PerformanceCommand
+
+passwordCracker:
+  rulesDirs:
+    - %module%/config/rules/
+  wordlistDirs:
+    - %module%/config/wordlists/

--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -16,12 +16,12 @@
 namespace Hypernode\Magento\Command\Hypernode\Performance;
 
 use Hypernode\Magento\Command\AbstractHypernodeCommand;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 /**
  * Class CacheWarmerCommand


### PR DESCRIPTION
This was possible by initializing Magento only when it's necessary. Also got rid of dependency on `\Varien_Simplexml_Element` by using `\SimpleXMLElement` instead. 
Additionally, I added some information to the README as well on how to install the addons for n98-magerun2 as well(it's quite easy).

It's a rough change, but I think this is a step into the right direction. Please let me know if there's something that needs to be changed.