### PR TITLE
detect magento before reading sitemap

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -88,6 +88,12 @@ class PerformanceCommand extends AbstractHypernodeCommand
             $this->_options['compare-url'] = $this->getEffectiveUrl($this->_options['compare-url']);
         }
 
+        try {
+            $this->detectMagento($output);
+            $this->initMagento();
+        } catch (\Exception $e) {
+        }
+
         // get sitemaps to process
         if ($this->_options['sitemap']) {
             $sitemapFromInput = $this->getSitemapFromInput($this->_options);
@@ -97,10 +103,6 @@ class PerformanceCommand extends AbstractHypernodeCommand
                 $this->_sitemaps = $sitemapFromInput;
             }
         } else {
-            $this->detectMagento($output);
-            if (!$this->initMagento()) {
-                return;
-            }
 
             if (intval($this->getApplication()->getMagentoMajorVersion()) === 2) {
                 $output->writeln(


### PR DESCRIPTION
it looks like the sitemap processing can only transform plaintext lists
to xml if the file is not relative to the magento path, which is rather
strange. anyway, this requires that the $this->_magentoRootFolder is set
before getting the sitemap from file.

```bash
app@s2ls53-vdloo-magweb-do:~/public$ magerun hypernode:performance --silent --limit 3 --compare-url='vdloo.hypernode.io' --sitemap /tmp/sitemap.txt  --current-url='vdloo.hypernode.io'
[[[{"url":"http:\/\/vdloo.hypernode.io\/","status":200,"ttfb":0.527022,"comparison_key":"\/"},{"url":"http:\/\/vdloo.hypernode.io\/","status":200,"ttfb":0.364185,"comparison_key":"\/"}],[{"url":"http:\/\/vdloo.hypernode.io\/home","status":200,"ttfb":0.356803,"comparison_key":"\/home"},{"url":"http:\/\/vdloo.hypernode.io\/home","status":200,"ttfb":0.347384,"comparison_key":"\/home"}],[{"url":"http:\/\/vdloo.hypernode.io\/about-magento-demo-store","status":200,"ttfb":0.352568,"comparison_key":"\/about-magento-demo-store"},{"url":"http:\/\/vdloo.hypernode.io\/about-magento-demo-store","status":200,"ttfb":0.353977,"comparison_key":"\/about-magento-demo-store"}]]]
app@s2ls53-vdloo-magweb-do:~/public$ exit
root@s2ls53-vdloo-magweb-do ~ # dpkg -i magerun-hypernode_20170823.173851_all.deb 
(Reading database ... 113400 files and directories currently installed.)
Preparing to unpack magerun-hypernode_20170823.173851_all.deb ...
Unpacking magerun-hypernode (20170823.173851) over (20170404.1452) ...
Setting up magerun-hypernode (20170823.173851) ...
root@s2ls53-vdloo-magweb-do ~ # su app
app@s2ls53-vdloo-magweb-do:/root$ cd /data/web/public/
app@s2ls53-vdloo-magweb-do:~/public$ magerun hypernode:performance --silent --limit 3 --compare-url='vdloo.hypernode.io' --sitemap /tmp/sitemap.txt  --current-url='vdloo.hypernode.io'
PHP Warning:  SimpleXMLElement::__construct(): Entity: line 1: parser error : Start tag expected, '<' not found in /usr/local/share/n98-magerun/modules/Hypernode/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php on line 478
PHP Warning:  SimpleXMLElement::__construct(): http://vdloo.hypernode.io/ in /usr/local/share/n98-magerun/modules/Hypernode/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php on line 478
PHP Warning:  SimpleXMLElement::__construct(): ^ in /usr/local/share/n98-magerun/modules/Hypernode/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php on line 478
String could not be parsed as XML /tmp/sitemap.txt
```