### PR TITLE
fix only variables should be passed by ref

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -483,7 +483,8 @@ class PerformanceCommand extends AbstractHypernodeCommand
 
                     // converting a txt of urls to magento sitemap structure (hypernode internal)
                 } elseif (file_exists($sitemap['relative_path'])) {
-                    if (end(explode('.', $sitemap['relative_path'])) == 'txt') {
+		    $path_exploded = explode('.', $sitemap['relative_path']);
+                    if (end($path_exploded) == 'txt') {
                         $xml = new \SimpleXMLElement($this->convertTxtToXml(file_get_contents($sitemap['relative_path'])));
                     } else {
                         $output->writeln('<error>Only a txt url list is currently supported for absolute paths.</error>');


### PR DESCRIPTION
```
magerun2 hypernode:performance --silent --limit 3 --compare-url='reggy.hypernode.io' --sitemap /tmp/sitemap.txt  --current-url='reggy.hypernode.io'

  [Exception]
  Notice: Only variables should be passed by reference in /data/web/.n98-magerun/modules/hypernode-magerun/src/Hypernode/Magento/Command/Hypernode
  /Performance/PerformanceCommand.php on line 488

hypernode:performance [--sitemap [SITEMAP]] [--current-url [CURRENT-URL]] [--compare-url [COMPARE-URL]] [--silent] [--format [FORMAT]] [--limit [LIMIT]] [--totaltime] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [--root-dir [ROOT-DIR]] [--skip-config] [--skip-root-check] [--skip-core-commands [SKIP-CORE-COMMANDS]] [--] <command>
```

also see: https://stackoverflow.com/a/4636183/4158804

```
app@yqc1dr-reggy-magweb-do:~/public$ magerun2 hypernode:performance --silent --limit 3 --compare-url='reggy.hypernode.io' --sitemap /tmp/sitemap.txt  --current-url='reggy.hypernode.io' 
[[[{"url":"https:\/\/reggy.hypernode.io\/","status":200,"ttfb":0.083071,"comparison_key":"\/"},{"url":"https:\/\/reggy.hypernode.io\/","status":200,"ttfb":0.073009,"comparison_key":"\/"}],[{"url":"https:\/\/reggy.hypernode.io\/home","status":200,"ttfb":0.077737,"comparison_key":"\/home"},{"url":"https:\/\/reggy.hypernode.io\/home","status":200,"ttfb":0.094071,"comparison_key":"\/home"}],[{"url":"https:\/\/reggy.hypernode.io\/about-magento-demo-store","status":404,"ttfb":0.076522,"comparison_key":"\/about-magento-demo-store"},{"url":"https:\/\/reggy.hypernode.io\/about-magento-demo-store","status":404,"ttfb":0.073811,"comparison_key":"\/about-magento-demo-store"}]]]
```