### PR TITLE
add hypernode:performance to magerun2 systemwide

### DIFF
--- a/debian/magerun-hypernode.install
+++ b/debian/magerun-hypernode.install
@@ -3,5 +3,6 @@
 src/ /usr/local/share/n98-magerun/modules/Hypernode/
 n98-magerun.yaml /usr/local/share/n98-magerun/modules/Hypernode/
 config/ /usr/local/share/n98-magerun/modules/Hypernode/
-
-
+src/ /usr/local/share/n98-magerun2/modules/Hypernode/
+n98-magerun2.yaml /usr/local/share/n98-magerun2/modules/Hypernode/
+config/ /usr/local/share/n98-magerun2/modules/Hypernode/


### PR DESCRIPTION
install the magerun2 [compatible modules](https://github.com/Hypernode/hypernode-magerun/blob/master/n98-magerun2.yaml) systemwide so people don't have to manually [link the module](https://github.com/Hypernode/hypernode-magerun#installation) in their home directory to benchmark magento 2 shops
```
app@j6yrvm-suusshop-magweb-do:~$ magerun2 | grep hypernode 
 hypernode
  hypernode:performance           Generate a performance report based on sitemaps.
```