### PR TITLE
run vagrant tests using the xenial image

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -27,6 +27,7 @@ PYTHONPATH=${HYPERNODE_VAGRANT_RUNNER_DIR}/tools/hypernode-vagrant-runner \
     --project-path="$PROJECT_DIRECTORY" \
     --command-to-run="$TEST_COMMAND" \
     --user="$TEST_USER" \
+    --xenial \
     --enable-xdebug \
     "$@"  # All other arguments. So you can run ./runtests.sh -1 or --help for example
 


### PR DESCRIPTION
not the old precise image that has since been deprecated

```
Time: 20.64 seconds, Memory: 32.00MB

OK (213 tests, 236 assertions)
Looks like everything is OK

Press enter to run the run the command again.
```