### PR TITLE
benchmark remote site when magento sitemap is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
   global:
     - DB=mysql
   matrix:
-    - MAGENTO_VERSION="magento-mirror-1.4.2.0" INSTALL_SAMPLE_DATA=yes
-    - MAGENTO_VERSION="magento-mirror-1.5.1.0" INSTALL_SAMPLE_DATA=yes
-    - MAGENTO_VERSION="magento-mirror-1.6.2.0" INSTALL_SAMPLE_DATA=yes
-    - MAGENTO_VERSION="magento-mirror-1.7.0.2" INSTALL_SAMPLE_DATA=yes
     - MAGENTO_VERSION="magento-mirror-1.8.1.0" INSTALL_SAMPLE_DATA=yes
     - MAGENTO_VERSION="magento-mirror-1.9.2.1" INSTALL_SAMPLE_DATA=no
     - MAGENTO_VERSION="magento-mirror-1.9.2.4" INSTALL_SAMPLE_DATA=no
@@ -27,14 +23,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.4.2.0" DB=mysql INSTALL_SAMPLE_DATA=yes
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.5.1.0" DB=mysql INSTALL_SAMPLE_DATA=yes
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.6.2.0" DB=mysql INSTALL_SAMPLE_DATA=yes
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.7.0.2" DB=mysql INSTALL_SAMPLE_DATA=yes
     - php: 7.0
       env: MAGENTO_VERSION="magento-mirror-1.8.1.0" DB=mysql INSTALL_SAMPLE_DATA=yes
     - php: 7.0

--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -506,7 +506,7 @@ class PerformanceCommand extends AbstractHypernodeCommand
 
                 $replace = false;
                 // finding out which replace strategy to use
-                if ($this->_options['sitemap'] && $this->_options['compare-url'] && $this->_options['current-url']) {
+                if ($this->_options['compare-url'] && $this->_options['current-url']) {
                     $replace = 3; // Replace and compare
                 } elseif ($requestSet['metadata']['base_url']) {
                     if (!$this->matchUrls($requestSet['metadata']['base_url'], $urls[0])['status']) {


### PR DESCRIPTION
currently, running the benchmark with a specified sitemap like so:
```
magerun hypernode:performance --limit 2 --silent --compare-url 'tim.hypernode.io' --sitemap /tmp/sitemap.txt --current-url 'vdloo.hypernode.io'
```
would benchmark the urls in the specified sitemap on tim.hypernode.io and on the remote vdloo.hypernode.io, but when the sitemap is not specified and the sitemap registered in Magento is used the remote shop is not benchmarked but only the local domain:
```
magerun hypernode:performance --limit 2 --silent --compare-url='tim.hypernode.io' --current-url='vdloo.hypernode.io'
```

before:
```
[[[{"url":"http:\/\/tim.hypernode.io\/women\/new-arrivals.html","status":200,"ttfb":0.150267,"comparison_key":"\/women\/new-arrivals.html"}],[{"url":"http:\/\/tim.hypernode.io\/women\/tops-blouses.html","status":200,"ttfb":0.127359,"comparison_key":"\/women\/tops-blouses.html"}]]]
```

after:
```
[[[{"url":"http:\/\/vdloo.hypernode.io\/women\/new-arrivals.html","status":200,"ttfb":0.523847,"comparison_key":"\/women\/new-arrivals.html"},{"url":"http:\/\/tim.hypernode.io\/women\/new-arrivals.html","status":200,"ttfb":0.167771,"comparison_key":"\/women\/new-arrivals.html"}],[{"url":"http:\/\/vdloo.hypernode.io\/women\/tops-blouses.html","status":200,"ttfb":0.488059,"comparison_key":"\/women\/tops-blouses.html"},{"url":"http:\/\/tim.hypernode.io\/women\/tops-blouses.html","status":200,"ttfb":0.170459,"comparison_key":"\/women\/tops-blouses.html"}]]]
```