### PR TITLE
remove magento 1.4..1.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
   global:
     - DB=mysql
   matrix:
-    - MAGENTO_VERSION="magento-mirror-1.4.2.0" INSTALL_SAMPLE_DATA=yes
-    - MAGENTO_VERSION="magento-mirror-1.5.1.0" INSTALL_SAMPLE_DATA=yes
-    - MAGENTO_VERSION="magento-mirror-1.6.2.0" INSTALL_SAMPLE_DATA=yes
-    - MAGENTO_VERSION="magento-mirror-1.7.0.2" INSTALL_SAMPLE_DATA=yes
     - MAGENTO_VERSION="magento-mirror-1.8.1.0" INSTALL_SAMPLE_DATA=yes
     - MAGENTO_VERSION="magento-mirror-1.9.2.1" INSTALL_SAMPLE_DATA=no
     - MAGENTO_VERSION="magento-mirror-1.9.2.4" INSTALL_SAMPLE_DATA=no
@@ -27,14 +23,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.4.2.0" DB=mysql INSTALL_SAMPLE_DATA=yes
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.5.1.0" DB=mysql INSTALL_SAMPLE_DATA=yes
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.6.2.0" DB=mysql INSTALL_SAMPLE_DATA=yes
-    - php: 7.0
-      env: MAGENTO_VERSION="magento-mirror-1.7.0.2" DB=mysql INSTALL_SAMPLE_DATA=yes
     - php: 7.0
       env: MAGENTO_VERSION="magento-mirror-1.8.1.0" DB=mysql INSTALL_SAMPLE_DATA=yes
     - php: 7.0


### PR DESCRIPTION
looks like Travis upgrade to mysql 5.6 where have_innodb was removed. We could patch the old installs [like so](https://stackoverflow.com/a/16870033/4158804) but these are very old version of Magento and we'll start running into more problems like this later so it is easier to just not test these ancient versions anymore.
```
  [RuntimeException]
  Installation failed (Exit code 1).
  FAILED
  ERROR: Database server does not support the InnoDB storage engine.

  [RuntimeException]
  Exit status 1 for command /home/travis/.phpenv/versions/5.5.38/bin/php -ddisplay_startup_errors=1 -ddisplay_errors=1 -derror_reporting=-1 -f '/home/travis/build/Hypernode/hypernode-magerun/magento-mirror-1.7.0.2/install.php' -- --license_agreement_accepted 'yes' --locale 'de_DE' --timezone 'Europe/Berlin' --db_host '127.0.0.1' --db_name 'magento_travis' --db_user 'root' --db_pass '' --db_prefix '' --url 'http://travis.magento.local/' --use_rewrites 'yes' --use_secure 'no' --secure_base_url 'https://travis.magento.local/' --use_secure_admin 'no' --admin_username 'admin' --admin_lastname 'Doe' --admin_firstname 'John' --admin_email 'john.doe@example.com' --admin_password 'password123' --session_save 'files' --admin_frontname 'admin' --backend_frontname 'admin' --default_currency 'EUR' --skip_url_validation 'yes'  2>&1. Output was:
  FAILED
  ERROR: Database server does not support the InnoDB storage engine.
```