### PR TITLE
Fix sitemap parsing

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -58,8 +58,6 @@ class PerformanceCommand extends AbstractHypernodeCommand
      */
     protected $_totalTime = false;
 
-    /** currently allowed sitemap filetypes  */
-    const SITEMAP_ALLOWED_TYPES = ['application/xml', 'text/plain'];
 
     /**
      * Configure Command
@@ -988,6 +986,10 @@ class PerformanceCommand extends AbstractHypernodeCommand
          * ([txt,xml]) and transform, parse, and return it.
          */
 
+        /** currently allowed sitemap filetypes  */
+         $sitemapAllowedTypes = ['application/xml', 'text/plain'];
+
+
         if (FileSystem::isAbsolutePath($sitemap['path'])) {
             /** path is absolute, pass it to the parser */
             $path = $sitemap['path'];
@@ -1003,8 +1005,8 @@ class PerformanceCommand extends AbstractHypernodeCommand
         }
 
         $type = mime_content_type($path);
-        if (!in_array($type, self::SITEMAP_ALLOWED_TYPES)) {
-            throw new \Exception('Invalid sitemap type: ' . $type . ' passed for: '. $path .' , should be: ' . implode(', ', self::SITEMAP_ALLOWED_TYPES));
+        if (!in_array($type, $sitemapAllowedTypes)) {
+            throw new \Exception('Invalid sitemap type: ' . $type . ' passed for: '. $path .' , should be: ' . implode(', ', $sitemapAllowedTypes));
         }
 
         if ($type === 'text/plain') {

--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -976,7 +976,6 @@ class PerformanceCommand extends AbstractHypernodeCommand
     /**
      * @param $sitemap
      *
-     * @return array
      * @throws \Exception
      */
     protected function getSitemapXmlFromFile($sitemap)
@@ -1005,7 +1004,7 @@ class PerformanceCommand extends AbstractHypernodeCommand
 
         $type = mime_content_type($path);
         if (!in_array($type, self::SITEMAP_ALLOWED_TYPES)) {
-            throw new \Exception('Invalid sitemap type passed, should be: ' . implode(',', self::SITEMAP_ALLOWED_TYPES));
+            throw new \Exception('Invalid sitemap type: ' . $type . ' passed for: '. $path .' , should be: ' . implode(', ', self::SITEMAP_ALLOWED_TYPES));
         }
 
         if ($type === 'text/plain') {

--- a/src/Hypernode/Util/FileSystem.php
+++ b/src/Hypernode/Util/FileSystem.php
@@ -9,6 +9,8 @@ class FileSystem
 
     public static function isAbsolutePath($file)
     {
+        /** copied from http://symfony.com/doc/current/components/filesystem.html */
+
         return strspn($file, '/\\', 0, 1)
             || (strlen($file) > 3 && ctype_alpha($file[0])
                 && substr($file, 1, 1) === ':'

--- a/src/Hypernode/Util/FileSystem.php
+++ b/src/Hypernode/Util/FileSystem.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace Hypernode\Util;
+
+
+class FileSystem
+{
+
+    public static function isAbsolutePath($file)
+    {
+        return strspn($file, '/\\', 0, 1)
+            || (strlen($file) > 3 && ctype_alpha($file[0])
+                && substr($file, 1, 1) === ':'
+                && strspn($file, '/\\', 2, 1)
+            )
+            || null !== parse_url($file, PHP_URL_SCHEME)
+            ;
+    }
+
+
+}

--- a/src/Hypernode/Util/FileSystem.php
+++ b/src/Hypernode/Util/FileSystem.php
@@ -20,5 +20,4 @@ class FileSystem
             ;
     }
 
-
 }


### PR DESCRIPTION
This is an attempt to refactor the way the sitemaps are parsed and handled.

Primary focus has been on local files, but the exception handling flow has been changed for remote ones as well. 

We've changed the way relative and absolute paths are handled, there is now a Hypernode\Util\Filesystem class that checks if a path is relative or absolute, this is based on the symfony framework.

Once we have a complete path (either absolute or resolved relative (resolved based on the magerun rootdir) we check if the file exists, and if it exists we check if it is a filetype we can handle (currently plain/text and application/xml), then we handle it accordingly.

This means the situation where you can only pass a txt file on a path outside the rootdir, or the situation where even absolute paths are first checked for existence inside the rootdir are now gone.
