### PR TITLE
Remove ignoring platform requirements and add php 5.6 in travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
 
 php:
   - 5.5
+  - 5.6
   - 7.0
 
 env:
@@ -45,7 +46,7 @@ before_install:
   - travis_retry composer self-update
 
 install:
-  - travis_retry composer install --prefer-source --no-interaction --ignore-platform-reqs
+  - travis_retry composer install --prefer-source --no-interaction
 
 before_script:
   - source build/travis/before_script.sh


### PR DESCRIPTION
Ignoring platform requirements on composer install can cause incompatible dependency's to be installed. Removing this parameter resolves #67.
Additionally, I've added php 5.6 to be included with the tests.