### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ php:
   - 5.6
   - 7.0
 
+git:
+  depth: 5
+
 env:
   global:
     - DB=mysql


### PR DESCRIPTION
By default Travis CI clones the last 50 commits. This should improve the time needed for the builds.