### PR TITLE
Increase Process timeout to prevent timeout errors on reading big system logs

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Log/ParseLogCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Log/ParseLogCommand.php
@@ -55,6 +55,7 @@ class ParseLogCommand extends AbstractHypernodeCommand
 
         if ($logPath) {
             $process = new Process("cut -d ' ' -f 2- " . $logPath . " | sort | uniq -c | sort -n -k 1 | tail -" . $input->getArgument('top') . "");
+            $process->setTimeout($process->getTimeout() * 10);
 
             $process->run(function ($type, $buffer) {
 


### PR DESCRIPTION
I had a Magento 1 instance with a log of 1.1 Gb and got the following error when running `n98-magerun.phar hypernode:log-analyses -vv -- 30`:

                         
      Top log messages.  
                         
      [Symfony\Component\Process\Exception\ProcessTimedOutException]                                                                                                    
      The process "cut -d ' ' -f 2- /path/to/magento/var/log/system.log | sort | uniq -c | sort -n -k 1 | tail -30" exceeded the timeout of 60 seconds.  

    Exception trace:
     () at phar:///path/to/magento/n98-magerun.phar/vendor/symfony/process/Process.php:1198
     Symfony\Component\Process\Process->checkTimeout() at phar:///path/to/magento/n98-magerun.phar/vendor/symfony/process/Process.php:361
     Symfony\Component\Process\Process->wait() at phar:///path/to/magento/n98-magerun.phar/vendor/symfony/process/Process.php:203
     Symfony\Component\Process\Process->run() at ~/.n98-magerun/modules/hypernode-magerun/src/Hypernode/Magento/Command/Hypernode/Log/ParseLogCommand.php:64
     Hypernode\Magento\Command\Hypernode\Log\ParseLogCommand->execute() at phar:///path/to/magento/n98-magerun.phar/vendor/symfony/console/Command/Command.php:264
     Symfony\Component\Console\Command\Command->run() at phar:///path/to/magento/n98-magerun.phar/src/N98/Magento/Command/AbstractMagentoCommand.php:473
     N98\Magento\Command\AbstractMagentoCommand->run() at phar:///path/to/magento/n98-magerun.phar/vendor/symfony/console/Application.php:868
     Symfony\Component\Console\Application->doRunCommand() at phar:///path/to/magento/n98-magerun.phar/vendor/symfony/console/Application.php:191
     Symfony\Component\Console\Application->doRun() at phar:///path/to/magento/n98-magerun.phar/src/N98/Magento/Application.php:610
     N98\Magento\Application->doRun() at phar:///path/to/magento/n98-magerun.phar/vendor/symfony/console/Application.php:122
     Symfony\Component\Console\Application->run() at phar:///path/to/magento/n98-magerun.phar/src/N98/Magento/Application.php:642
     N98\Magento\Application->run() at /path/to/magento/n98-magerun.phar:22

    hypernode:log-analyses [-l|--log [LOG]] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [--root-dir [ROOT-DIR]] [--skip-config] [--skip-root-check] [--developer-mode] [--] <command> [<top>]

So I added an increase of the timeout (by tenfold) on this specific Process, which by default is 60 seconds (as seen in the output above) and thus will become 600 seconds.