### PR TITLE
Allow different XML mime type in PHP 7.2

### DIFF
--- a/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
+++ b/src/Hypernode/Magento/Command/Hypernode/Performance/PerformanceCommand.php
@@ -989,7 +989,7 @@ class PerformanceCommand extends AbstractHypernodeCommand
          */
 
         /** currently allowed sitemap filetypes  */
-         $sitemapAllowedTypes = ['application/xml', 'text/plain'];
+         $sitemapAllowedTypes = ['application/xml', 'text/xml', 'text/plain'];
 
 
         if (FileSystem::isAbsolutePath($sitemap['path'])) {
@@ -1013,7 +1013,7 @@ class PerformanceCommand extends AbstractHypernodeCommand
 
         if ($type === 'text/plain') {
             $xml = new \SimpleXMLElement($this->convertTxtToXml(file($sitemap['path'], FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)));
-        } elseif ($type === 'application/xml') {
+        } elseif ($type === 'application/xml' || $type === 'text/xml') {
             $xml = new \SimpleXMLElement(file_get_contents($path));
         }
 


### PR DESCRIPTION
The function mime_content_type() returns text/xml instead of application/xml on PHP 7.2. This type was added.

Refer to the following for more info:

* https://bugs.php.net/bug.php?id=75380
* https://github.com/file/file/commit/cee2b49cdb6c995c1a449aa399f80145e28c6a8a
